### PR TITLE
Replace numeric IDs with slugs and use route model binding

### DIFF
--- a/app/Http/Controllers/Api/ChannelController.php
+++ b/app/Http/Controllers/Api/ChannelController.php
@@ -61,9 +61,9 @@ class ChannelController
         //        broadcast(new ChannelDeleted($channelId));
 
         $previousUrl = url()->previous();
-        
+
         // If the user was viewing the channel that was just deleted, redirect them to the server's text/voice/whiteboard root.
-        if (str_contains($previousUrl, '/' . $channelSlug)) {
+        if (str_contains($previousUrl, '/'.$channelSlug)) {
             if ($type === ChannelType::Text->value || $type === ChannelType::Text) {
                 return redirect()->route('home.text', ['server' => $server->slug]);
             } elseif ($type === ChannelType::Voice->value || $type === ChannelType::Voice) {
@@ -71,6 +71,7 @@ class ChannelController
             } elseif ($type === ChannelType::Whiteboard->value || $type === ChannelType::Whiteboard) {
                 return redirect()->route('home.whiteboard', ['server' => $server->slug]);
             }
+
             return redirect()->route('home.server', ['server' => $server->slug]);
         }
 

--- a/app/Http/Controllers/Api/ChannelController.php
+++ b/app/Http/Controllers/Api/ChannelController.php
@@ -26,7 +26,7 @@ class ChannelController
 
         //        broadcast(new ChannelCreated($serverId));
 
-        return back();
+        return back()->with('message', 'Channel added to server successfully.');
     }
 
     public function edit(Request $request, Server $server, Channel $channel)
@@ -43,7 +43,7 @@ class ChannelController
 
         //        broadcast(new ChannelEdited($channel->id));
 
-        return back();
+        return back()->with('message', 'Channel updated successfully.');
     }
 
     public function delete(Server $server, Channel $channel)
@@ -65,17 +65,17 @@ class ChannelController
         // If the user was viewing the channel that was just deleted, redirect them to the server's text/voice/whiteboard root.
         if (str_contains($previousUrl, '/'.$channelSlug)) {
             if ($type === ChannelType::Text->value || $type === ChannelType::Text) {
-                return redirect()->route('home.text', ['server' => $server->slug]);
+                return redirect()->route('home.text', ['server' => $server->slug])->with('message', 'Channel deleted successfully.');
             } elseif ($type === ChannelType::Voice->value || $type === ChannelType::Voice) {
-                return redirect()->route('home.voice', ['server' => $server->slug]);
+                return redirect()->route('home.voice', ['server' => $server->slug])->with('message', 'Channel deleted successfully.');
             } elseif ($type === ChannelType::Whiteboard->value || $type === ChannelType::Whiteboard) {
-                return redirect()->route('home.whiteboard', ['server' => $server->slug]);
+                return redirect()->route('home.whiteboard', ['server' => $server->slug])->with('message', 'Channel deleted successfully.');
             }
 
-            return redirect()->route('home.server', ['server' => $server->slug]);
+            return redirect()->route('home.server', ['server' => $server->slug])->with('message', 'Channel deleted successfully.');
         }
 
-        return back();
+        return back()->with('message', 'Channel deleted successfully.');
     }
 
     public function upload(Request $request, Server $server, Channel $channel)

--- a/app/Http/Controllers/Api/ChannelController.php
+++ b/app/Http/Controllers/Api/ChannelController.php
@@ -11,78 +11,75 @@ use Illuminate\Http\Request;
 
 class ChannelController
 {
-    public function create(Request $request, int $serverId)
+    public function create(Request $request, Server $server)
     {
         $request->validate(['name' => 'required|string|max:50', 'type' => 'required|in:'.implode(',', array_column(ChannelType::cases(), 'value'))]);
 
-        $server = Server::find($serverId);
-
-        if (! $server) {
-            return response()->json(['message' => 'Server not found.'], 404);
-        }
+        $serverId = $server->id;
 
         setPermissionsTeamId($serverId);
         if (! Auth::user()->hasPermissionTo('CAN_CREATE_CHANNEL')) {
-            return response()->json(['message' => 'Forbidden.'], 403);
+            abort(403, 'Forbidden.');
         }
 
         Channel::create(['name' => $request->get('name'), 'type' => $request->get('type'), 'server_id' => $serverId]);
 
         //        broadcast(new ChannelCreated($serverId));
 
-        return response()->json(['message' => 'Channel added to server successfully.']);
+        return back();
     }
 
-    public function edit(Request $request, int $channelId)
+    public function edit(Request $request, Server $server, Channel $channel)
     {
         $request->validate(['name' => 'required|string|max:50']);
 
-        $channel = Channel::find($channelId);
-
-        if (! $channel) {
-            return response()->json(['message' => 'Channel not found.'], 404);
-        }
-
         setPermissionsTeamId($channel->server_id);
         if (! Auth::user()->hasPermissionTo('CAN_EDIT_CHANNEL')) {
-            return response()->json(['message' => 'Forbidden.'], 403);
+            abort(403, 'Forbidden.');
         }
 
         $channel->name = $request->get('name');
         $channel->save();
 
-        //        broadcast(new ChannelEdited($channelId));
+        //        broadcast(new ChannelEdited($channel->id));
 
-        return response()->json(['message' => 'Channel updated successfully.']);
+        return back();
     }
 
-    public function delete(int $channelId)
+    public function delete(Server $server, Channel $channel)
     {
-        $channel = Channel::find($channelId);
-        if (! $channel) {
-            return response()->json(['message' => 'Channel not found.'], 404);
-        }
-
         setPermissionsTeamId($channel->server_id);
         if (! Auth::user()->hasPermissionTo('CAN_DELETE_CHANNEL')) {
-            return response()->json(['message' => 'Forbidden.'], 403);
+            abort(403, 'Forbidden.');
         }
 
+        $type = $channel->type;
+        $channelId = $channel->id;
+        $channelSlug = $channel->slug;
         $channel->delete();
 
         //        broadcast(new ChannelDeleted($channelId));
 
-        return response()->json(['message' => 'Channel deleted successfully.']);
+        $previousUrl = url()->previous();
+        
+        // If the user was viewing the channel that was just deleted, redirect them to the server's text/voice/whiteboard root.
+        if (str_contains($previousUrl, '/' . $channelSlug)) {
+            if ($type === ChannelType::Text->value || $type === ChannelType::Text) {
+                return redirect()->route('home.text', ['server' => $server->slug]);
+            } elseif ($type === ChannelType::Voice->value || $type === ChannelType::Voice) {
+                return redirect()->route('home.voice', ['server' => $server->slug]);
+            } elseif ($type === ChannelType::Whiteboard->value || $type === ChannelType::Whiteboard) {
+                return redirect()->route('home.whiteboard', ['server' => $server->slug]);
+            }
+            return redirect()->route('home.server', ['server' => $server->slug]);
+        }
+
+        return back();
     }
 
-    public function upload(Request $request, int $channelId)
+    public function upload(Request $request, Server $server, Channel $channel)
     {
         $request->validate(['audio' => 'required|file|mimes:webm,mp3,wav,ogg|mimetypes:audio/webm,audio/mpeg,audio/wav,audio/ogg']);
-
-        $channel = Channel::find($channelId);
-        if (! $channel) {
-            return response()->json(['message' => 'Channel not found.'], 404);
-        }
 
         $audioData = file_get_contents($request->file('audio')->getRealPath());
 

--- a/app/Http/Controllers/Api/MessageController.php
+++ b/app/Http/Controllers/Api/MessageController.php
@@ -5,13 +5,14 @@ namespace App\Http\Controllers\Api;
 use App\Enums\MessageType;
 use App\Models\Channel;
 use App\Models\Message;
+use App\Models\Server;
 use Auth;
 use Illuminate\Http\Request;
 use Storage;
 
 class MessageController
 {
-    public function create(Request $request, int $channelId)
+    public function create(Request $request, Server $server, Channel $channel)
     {
         $request->validate([
             'type' => 'required|in:'.implode(',', array_column(MessageType::cases(), 'value')),
@@ -21,15 +22,9 @@ class MessageController
             'mdata' => $request->type === MessageType::Text->value ? 'required|string|max:500' : 'required|file|max:200000000',
         ]);
 
-        $channel = Channel::find($channelId);
-
-        if (! $channel) {
-            return response()->json(['message' => 'Channel not found'], 404);
-        }
-
         setPermissionsTeamId($channel->server_id);
         if (! Auth::user()->hasPermissionTo('CAN_CREATE_MESSAGE')) {
-            return response()->json(['message' => 'Forbidden.'], 403);
+            abort(403, 'Forbidden.');
         }
 
         if ($request->type !== MessageType::Text->value && $request->file('mdata')?->isValid()) {
@@ -40,7 +35,7 @@ class MessageController
                 [$width, $height] = getimagesize($file->getRealPath());
 
                 if ($width > 1920 || $height > 1080) {
-                    return response()->json(['errors' => ['icon' => ['The image must not exceed 1920x1080 pixels.']], 'message' => 'The image must not exceed 1920x1080 pixels.'], 422);
+                    return back()->withErrors(['mdata' => 'The image must not exceed 1920x1080 pixels.']);
                 }
             }
 
@@ -57,7 +52,7 @@ class MessageController
 
         //        broadcast(new MessageCreated($request->mdata, $request->user()->id, $channel->id));
 
-        return response()->json(['message' => 'Message created'], 201);
+        return back();
     }
 
     public function edit(Request $request, int $messageId)
@@ -69,15 +64,15 @@ class MessageController
         $message = Message::find($messageId);
 
         if (! $message) {
-            return response()->json(['message' => 'Message not found'], 404);
+            abort(404, 'Message not found');
         }
 
         if ($message->user_id !== Auth::id()) {
-            return response()->json(['message' => 'Forbidden.'], 403);
+            abort(403, 'Forbidden.');
         }
 
         if ($message->type != MessageType::Text->value) {
-            return response()->json(['message' => 'Message can not be edited'], 400);
+            abort(400, 'Message can not be edited');
         }
 
         $message->update([
@@ -87,7 +82,7 @@ class MessageController
 
         //        broadcast(new MessageEdited($message->id, $message->channel_id, $request->user()->id));
 
-        return response()->json(['message' => 'Message updated'], 201);
+        return back();
     }
 
     public function delete(int $messageId)
@@ -95,12 +90,12 @@ class MessageController
         $message = Message::find($messageId);
 
         if (! $message) {
-            return response()->json(['message' => 'Message not found'], 404);
+            abort(404, 'Message not found');
         }
 
         setPermissionsTeamId($message->channel->server_id);
         if ($message->user->id !== Auth::id() && ! Auth::user()->hasPermissionTo('CAN_DELETE_MESSAGE')) {
-            return response()->json(['message' => 'Forbidden.'], 403);
+            abort(403, 'Forbidden.');
         }
 
         if ($message->type != MessageType::Text->value) {
@@ -118,6 +113,6 @@ class MessageController
         //            $request->user()->id
         //        ));
 
-        return response()->json(['message' => 'Message deleted'], 201);
+        return back();
     }
 }

--- a/app/Http/Controllers/Api/MessageController.php
+++ b/app/Http/Controllers/Api/MessageController.php
@@ -52,7 +52,7 @@ class MessageController
 
         //        broadcast(new MessageCreated($request->mdata, $request->user()->id, $channel->id));
 
-        return back();
+        return back()->with('message', 'Message created');
     }
 
     public function edit(Request $request, int $messageId)
@@ -82,7 +82,7 @@ class MessageController
 
         //        broadcast(new MessageEdited($message->id, $message->channel_id, $request->user()->id));
 
-        return back();
+        return back()->with('message', 'Message updated');
     }
 
     public function delete(int $messageId)
@@ -113,6 +113,6 @@ class MessageController
         //            $request->user()->id
         //        ));
 
-        return back();
+        return back()->with('message', 'Message deleted');
     }
 }

--- a/app/Http/Controllers/Api/RoleController.php
+++ b/app/Http/Controllers/Api/RoleController.php
@@ -143,7 +143,7 @@ class RoleController extends Controller
 
         $user->assignRole($role);
 
-        return back();
+        return back()->with('message', 'Role added successfully.');
     }
 
     public function removeUser(int $roleId, int $userId)
@@ -166,6 +166,6 @@ class RoleController extends Controller
 
         $user->removeRole($role);
 
-        return back();
+        return back()->with('message', 'Role deleted successfully.');
     }
 }

--- a/app/Http/Controllers/Api/RoleController.php
+++ b/app/Http/Controllers/Api/RoleController.php
@@ -12,17 +12,14 @@ use Inertia\Inertia;
 
 class RoleController extends Controller
 {
-    public function index($serverId)
+    public function index(Server $server)
     {
-        $server = Server::with('roles')->find($serverId);
-        if (! $server) {
-            return response()->json(['message' => 'Server not found.'], 404);
-        }
+        $server->load('roles');
 
         return response()->json($server->roles);
     }
 
-    public function create(Request $request, int $serverId)
+    public function create(Request $request, Server $server)
     {
         $request->validate([
             'name' => 'required|string|max:255',
@@ -31,11 +28,7 @@ class RoleController extends Controller
             'importance' => 'required|integer|min:0',
         ]);
 
-        $server = Server::find($serverId);
-
-        if (! $server) {
-            return response()->json(['message' => 'Server not found.'], 404);
-        }
+        $serverId = $server->id;
 
         setPermissionsTeamId($serverId);
         if (! Auth::user()->hasPermissionTo('CAN_CREATE_ROLE')) {
@@ -107,13 +100,8 @@ class RoleController extends Controller
         return response()->json(['message' => 'Role deleted successfully.']);
     }
 
-    public function showSettings($serverId)
+    public function showSettings(Server $server)
     {
-        $server = Server::find($serverId);
-        if (! $server) {
-            return response()->json(['message' => 'Server not found.'], 404);
-        }
-
         return Inertia::render('Settings/Role')->with([
             'selectedServer' => $server,
             'selectedServer.users' => $server->users,
@@ -121,13 +109,9 @@ class RoleController extends Controller
         ]);
     }
 
-    public function showMembers($serverId)
+    public function showMembers(Server $server)
     {
-        $server = Server::find($serverId);
-        if (! $server) {
-            return response()->json(['message' => 'Server not found.'], 404);
-        }
-
+        $serverId = $server->id;
         setPermissionsTeamId($serverId);
 
         return Inertia::render('Settings/Members')->with([
@@ -145,21 +129,21 @@ class RoleController extends Controller
         $role = Role::with('server')->find($roleId);
 
         if (! $role) {
-            return response()->json(['message' => 'Role not found.'], 404);
+            abort(404, 'Role not found.');
         }
 
         if (! $user) {
-            return response()->json(['message' => 'User not found.'], 404);
+            abort(404, 'User not found.');
         }
 
         setPermissionsTeamId($role->server_id);
         if (! Auth::user()->hasPermissionTo('CAN_EDIT_MEMBER_ROLES') && ! Auth::user()->hasPermissionTo('CAN_MANAGE_ROLE')) {
-            return response()->json(['message' => 'Forbidden.'], 403);
+            abort(403, 'Forbidden.');
         }
 
         $user->assignRole($role);
 
-        return response()->json(['message' => 'Role added successfully.']);
+        return back();
     }
 
     public function removeUser(int $roleId, int $userId)
@@ -168,20 +152,20 @@ class RoleController extends Controller
         $role = Role::with('server')->find($roleId);
 
         if (! $role) {
-            return response()->json(['message' => 'Role not found.'], 404);
+            abort(404, 'Role not found.');
         }
 
         if (! $user) {
-            return response()->json(['message' => 'User not found.'], 404);
+            abort(404, 'User not found.');
         }
 
         setPermissionsTeamId($role->server_id);
         if (! Auth::user()->hasPermissionTo('CAN_EDIT_MEMBER_ROLES') && ! Auth::user()->hasPermissionTo('CAN_MANAGE_ROLE')) {
-            return response()->json(['message' => 'Forbidden.'], 403);
+            abort(403, 'Forbidden.');
         }
 
         $user->removeRole($role);
 
-        return response()->json(['message' => 'Role deleted successfully.']);
+        return back();
     }
 }

--- a/app/Http/Controllers/Api/ServerController.php
+++ b/app/Http/Controllers/Api/ServerController.php
@@ -58,7 +58,7 @@ class ServerController extends Controller
 
         //        broadcast(new ServerCreated($server->id, $server->name, $server->description, $server->icon));
 
-        return back();
+        return back()->with('message', 'Server created successfully.');
     }
 
     public function addUser(Request $request)
@@ -108,7 +108,7 @@ class ServerController extends Controller
 
         broadcast(new ServerLeft($request->user_id, $serverId));
 
-        return back();
+        return back()->with('message', 'User removed from server successfully.');
     }
 
     public function edit(Request $request, Server $server)
@@ -143,7 +143,7 @@ class ServerController extends Controller
 
         //        broadcast(new ServerEdited($serverId, $server->name, $server->description, $server->icon));
 
-        return back();
+        return back()->with('message', 'Server updated successfully.');
     }
 
     public function showSettings(Server $server)

--- a/app/Http/Controllers/Api/ServerController.php
+++ b/app/Http/Controllers/Api/ServerController.php
@@ -28,7 +28,7 @@ class ServerController extends Controller
             [$width, $height] = getimagesize($request->file('icon')->getRealPath());
 
             if ($width > 1920 || $height > 1080) {
-                return response()->json(['errors' => ['icon' => ['The image must not exceed 1920x1080 pixels.']], 'message' => 'The image must not exceed 1920x1080 pixels.'], 422);
+                return back()->withErrors(['icon' => 'The image must not exceed 1920x1080 pixels.']);
             }
 
             $path = $request->file('icon')->store('uploads', 'public');
@@ -58,7 +58,7 @@ class ServerController extends Controller
 
         //        broadcast(new ServerCreated($server->id, $server->name, $server->description, $server->icon));
 
-        return response()->json(['message' => 'Server created successfully.']);
+        return back();
     }
 
     public function addUser(Request $request)
@@ -87,34 +87,31 @@ class ServerController extends Controller
 
         broadcast(new ServerJoined(Auth::id(), $serverId));
 
+        // Note: addUser is called via fetchJson in bootstrap.ts, so we MUST return JSON!
         return response()->json(['message' => 'User added to server successfully.']);
     }
 
-    public function removeUser(Request $request, int $serverId)
+    public function removeUser(Request $request, Server $server)
     {
         $request->validate([
             'user_id' => 'required|exists:users,id',
         ]);
 
-        $server = Server::find($serverId);
-
-        if (! $server) {
-            return response()->json(['message' => 'Server not found.'], 404);
-        }
+        $serverId = $server->id;
 
         setPermissionsTeamId($serverId);
         if (! Auth::user()->hasPermissionTo('CAN_KICK')) {
-            return response()->json(['message' => 'Forbidden.'], 403);
+            abort(403, 'Forbidden.');
         }
 
         $server->users()->detach($request->user_id);
 
         broadcast(new ServerLeft($request->user_id, $serverId));
 
-        return response()->json(['message' => 'User removed from server successfully.']);
+        return back();
     }
 
-    public function edit(Request $request, int $serverId)
+    public function edit(Request $request, Server $server)
     {
         $request->validate([
             'name' => 'required|string|max:50',
@@ -122,22 +119,18 @@ class ServerController extends Controller
             'icon' => 'nullable|image|mimes:jpeg,png,jpg|max:2048',
         ]);
 
-        $server = Server::find($serverId);
-
-        if (! $server) {
-            return response()->json(['message' => 'Server not found.'], 404);
-        }
+        $serverId = $server->id;
 
         setPermissionsTeamId($serverId);
         if (! Auth::user()->hasPermissionTo('CAN_EDIT_SERVER')) {
-            return response()->json(['message' => 'Forbidden.'], 403);
+            abort(403, 'Forbidden.');
         }
 
         if ($request->file('icon')?->isValid()) {
             [$width, $height] = getimagesize($request->file('icon')->getRealPath());
 
             if ($width > 1920 || $height > 1080) {
-                return response()->json(['errors' => ['icon' => ['The image must not exceed 1920x1080 pixels.'], 'message' => 'The image must not exceed 1920x1080 pixels.']], 422);
+                return back()->withErrors(['icon' => 'The image must not exceed 1920x1080 pixels.']);
             }
 
             $path = $request->file('icon')->store('uploads', 'public');
@@ -150,16 +143,12 @@ class ServerController extends Controller
 
         //        broadcast(new ServerEdited($serverId, $server->name, $server->description, $server->icon));
 
-        return response()->json(['message' => 'Server updated successfully.']);
+        return back();
     }
 
-    public function showSettings(int $serverId)
+    public function showSettings(Server $server)
     {
-        $server = Server::find($serverId);
-        if (! $server) {
-            return response()->json(['message' => 'Server not found.'], 404);
-        }
-
+        $serverId = $server->id;
         setPermissionsTeamId($serverId);
         if (! Auth::user()->hasPermissionTo('CAN_EDIT_SERVER') && ! Auth::user()->hasPermissionTo('CAN_MANAGE_SERVER')) {
             return response()->json(['message' => 'Forbidden.'], 403);
@@ -172,14 +161,9 @@ class ServerController extends Controller
         ]);
     }
 
-    public function destroy(int $serverId)
+    public function destroy(Server $server)
     {
-        $server = Server::find($serverId);
-
-        if (! $server) {
-            return response()->json(['message' => 'Server not found.'], 404);
-        }
-
+        $serverId = $server->id;
         setPermissionsTeamId($serverId);
         if (! Auth::user()->hasPermissionTo('CAN_DELETE_SERVER')) {
             return response()->json(['message' => 'Forbidden.'], 403);
@@ -190,26 +174,21 @@ class ServerController extends Controller
         return redirect('/home');
     }
 
-    public function delete(int $serverId)
+    public function delete(Server $server)
     {
-        $server = Server::find($serverId);
-
-        if (! $server) {
-            return response()->json(['message' => 'Server not found.'], 404);
-        }
-
+        $serverId = $server->id;
         setPermissionsTeamId($serverId);
         if (! Auth::user()->hasPermissionTo('CAN_DELETE_SERVER')) {
-            return response()->json(['message' => 'Forbidden.'], 403);
+            abort(403, 'Forbidden.');
         }
 
         Role::where('server_id', $server->id)->delete();
         $server->delete();
 
-        return response()->json(['message' => 'Server deleted successfully.']);
+        return redirect('/home')->with('message', 'Server deleted successfully.');
     }
 
-    public function update(Request $request, int $serverId)
+    public function update(Request $request, Server $server)
     {
         $request->validate([
             'name' => 'required|string|max:50',
@@ -217,11 +196,7 @@ class ServerController extends Controller
             'icon' => 'nullable|image|mimes:jpeg,png,jpg,gif,webp|max:2048',
         ]);
 
-        $server = Server::find($serverId);
-        if (! $server) {
-            return redirect()->back()->withErrors(['message' => 'Server not found.']);
-        }
-
+        $serverId = $server->id;
         setPermissionsTeamId($serverId);
         if (! Auth::user()->hasPermissionTo('CAN_EDIT_SERVER')) {
             return response()->json(['message' => 'Forbidden.'], 403);
@@ -242,20 +217,14 @@ class ServerController extends Controller
         $server->description = $request->input('description', $server->description);
         $server->save();
 
-        return redirect()->route('settings.server', ['id' => $serverId])
+        return redirect()->route('settings.server', ['server' => $server])
             ->with('message', 'Server updated successfully.');
     }
 
-    public function leave(int $serverId)
+    public function leave(Server $server)
     {
-        $server = Server::find($serverId);
-
-        if (! $server) {
-            return response()->json(['message' => 'Server not found.'], 404);
-        }
-
         $server->users()->detach(Auth::id());
 
-        return response()->json(['message' => 'You have left the server.'], 200);
+        return redirect('/home')->with('message', 'You have left the server.');
     }
 }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -27,7 +27,7 @@ class HomeController extends Controller
             'selectedServer' => $server,
             'selectedServer.users' => $server->users,
             'selectedServer.roles' => $server->roles,
-            'inviteCode' => $server->id.'#'.hash('xxh32', (string)$server->id),
+            'inviteCode' => $server->id.'#'.hash('xxh32', (string) $server->id),
         ]);
     }
 
@@ -39,7 +39,7 @@ class HomeController extends Controller
             'selectedServer.users' => $server->users,
             'selectedServer.roles' => $server->roles,
             'channels' => $server->channels()->where('type', ChannelType::Text)->get(),
-            'inviteCode' => $server->id.'#'.hash('xxh32', (string)$server->id),
+            'inviteCode' => $server->id.'#'.hash('xxh32', (string) $server->id),
         ]);
     }
 
@@ -55,7 +55,7 @@ class HomeController extends Controller
             'messages' => Message::where('channel_id', $channel->id)->with('user')->get()->each(function (Message $message) {
                 $message['sender'] = fn (): User => $message->user;
             }),
-            'inviteCode' => $server->id.'#'.hash('xxh32', (string)$server->id),
+            'inviteCode' => $server->id.'#'.hash('xxh32', (string) $server->id),
         ]);
     }
 
@@ -70,7 +70,7 @@ class HomeController extends Controller
             'messages' => Message::where('channel_id', $channel->id)->with('user')->get()->each(function (Message $message) {
                 $message['sender'] = fn (): User => $message->user;
             }),
-            'inviteCode' => $server->id.'#'.hash('xxh32', (string)$server->id),
+            'inviteCode' => $server->id.'#'.hash('xxh32', (string) $server->id),
         ]);
     }
 
@@ -82,7 +82,7 @@ class HomeController extends Controller
             'selectedServer.users' => $server->users,
             'selectedServer.roles' => $server->roles,
             'channels' => $server->channels()->where('type', ChannelType::Voice)->get(),
-            'inviteCode' => $server->id.'#'.hash('xxh32', (string)$server->id),
+            'inviteCode' => $server->id.'#'.hash('xxh32', (string) $server->id),
         ]);
     }
 
@@ -95,7 +95,7 @@ class HomeController extends Controller
             'selectedServer.roles' => $server->roles,
             'selectedChannel' => $channel,
             'channels' => $server->channels()->where('type', ChannelType::Voice)->get(),
-            'inviteCode' => $server->id.'#'.hash('xxh32', (string)$server->id),
+            'inviteCode' => $server->id.'#'.hash('xxh32', (string) $server->id),
         ]);
     }
 
@@ -115,7 +115,7 @@ class HomeController extends Controller
             'selectedServer.roles' => $server->roles,
             'selectedChannel' => $channel,
             'channels' => $server->channels()->where('type', ChannelType::Whiteboard)->get(),
-            'inviteCode' => $server->id.'#'.hash('xxh32', (string)$server->id),
+            'inviteCode' => $server->id.'#'.hash('xxh32', (string) $server->id),
         ]);
     }
 
@@ -127,7 +127,7 @@ class HomeController extends Controller
             'selectedServer.users' => $server->users,
             'selectedServer.roles' => $server->roles,
             'channels' => $server->channels()->where('type', ChannelType::Whiteboard)->get(),
-            'inviteCode' => $server->id.'#'.hash('xxh32', (string)$server->id),
+            'inviteCode' => $server->id.'#'.hash('xxh32', (string) $server->id),
         ]);
     }
 }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -20,129 +20,114 @@ class HomeController extends Controller
         ]);
     }
 
-    public function server(Request $request, int $server): Response
+    public function server(Request $request, Server $server): Response
     {
-        $serverObj = Server::find($server);
-
         return Inertia::render('Home')->with([
             'servers' => $request->user()->servers,
-            'selectedServer' => $serverObj,
-            'selectedServer.users' => $serverObj->users,
-            'selectedServer.roles' => $serverObj->roles,
-            'inviteCode' => $server.'#'.hash('xxh32', $server),
+            'selectedServer' => $server,
+            'selectedServer.users' => $server->users,
+            'selectedServer.roles' => $server->roles,
+            'inviteCode' => $server->id.'#'.hash('xxh32', (string)$server->id),
         ]);
     }
 
-    public function text(Request $request, int $server): Response
+    public function text(Request $request, Server $server): Response
     {
-        $serverObj = Server::find($server);
-
         return Inertia::render('Text/Texting')->with([
             'servers' => $request->user()->servers,
-            'selectedServer' => $serverObj,
-            'selectedServer.users' => $serverObj->users,
-            'selectedServer.roles' => $serverObj->roles,
-            'channels' => $serverObj->channels()->where('type', ChannelType::Text)->get(),
-            'inviteCode' => $server.'#'.hash('xxh32', $server),
+            'selectedServer' => $server,
+            'selectedServer.users' => $server->users,
+            'selectedServer.roles' => $server->roles,
+            'channels' => $server->channels()->where('type', ChannelType::Text)->get(),
+            'inviteCode' => $server->id.'#'.hash('xxh32', (string)$server->id),
         ]);
     }
 
-    public function channel(Request $request, int $server, int $channel): Response
+    public function channel(Request $request, Server $server, Channel $channel): Response
     {
-        $serverObj = Server::find($server);
-
         return Inertia::render('Text/Texting', [
             'servers' => $request->user()->servers,
-            'selectedServer' => $serverObj,
-            'selectedServer.users' => $serverObj->users,
-            'selectedServer.roles' => $serverObj->roles,
-            'selectedChannel' => Channel::find($channel),
-            'channels' => $serverObj->channels()->where('type', ChannelType::Text)->get(),
-            'messages' => Message::where('channel_id', $channel)->with('user')->get()->each(function (Message $message) {
+            'selectedServer' => $server,
+            'selectedServer.users' => $server->users,
+            'selectedServer.roles' => $server->roles,
+            'selectedChannel' => $channel,
+            'channels' => $server->channels()->where('type', ChannelType::Text)->get(),
+            'messages' => Message::where('channel_id', $channel->id)->with('user')->get()->each(function (Message $message) {
                 $message['sender'] = fn (): User => $message->user;
             }),
-            'inviteCode' => $server.'#'.hash('xxh32', $server),
+            'inviteCode' => $server->id.'#'.hash('xxh32', (string)$server->id),
         ]);
     }
 
-    public function message(Request $request, int $server, int $channel, int $message): Response
+    public function message(Request $request, Server $server, Channel $channel, int $message): Response
     {
-        $serverObj = Server::find($server);
-
         return Inertia::render('Text/Texting', [
             'servers' => $request->user()->servers,
-            'selectedServer' => $serverObj,
-            'selectedChannel' => Channel::find($channel),
+            'selectedServer' => $server,
+            'selectedChannel' => $channel,
             'selectedMessage' => Message::find($message),
-            'channels' => $serverObj->channels()->where('type', ChannelType::Text)->get(),
-            'messages' => Message::where('channel_id', $channel)->with('user')->get()->each(function (Message $message) {
+            'channels' => $server->channels()->where('type', ChannelType::Text)->get(),
+            'messages' => Message::where('channel_id', $channel->id)->with('user')->get()->each(function (Message $message) {
                 $message['sender'] = fn (): User => $message->user;
             }),
-            'inviteCode' => $server.'#'.hash('xxh32', $server),
+            'inviteCode' => $server->id.'#'.hash('xxh32', (string)$server->id),
         ]);
     }
 
-    public function voice(Request $request, int $server): Response
+    public function voice(Request $request, Server $server): Response
     {
-        $serverObj = Server::find($server);
-
         return Inertia::render('Voice/Speaking', [
             'servers' => $request->user()->servers,
-            'selectedServer' => $serverObj,
-            'selectedServer.users' => $serverObj->users,
-            'selectedServer.roles' => $serverObj->roles,
-            'channels' => $serverObj->channels()->where('type', ChannelType::Voice)->get(),
-            'inviteCode' => $server.'#'.hash('xxh32', $server),
+            'selectedServer' => $server,
+            'selectedServer.users' => $server->users,
+            'selectedServer.roles' => $server->roles,
+            'channels' => $server->channels()->where('type', ChannelType::Voice)->get(),
+            'inviteCode' => $server->id.'#'.hash('xxh32', (string)$server->id),
         ]);
     }
 
-    public function vchannel(Request $request, int $server, int $channel): Response
+    public function vchannel(Request $request, Server $server, Channel $channel): Response
     {
-        $serverObj = Server::find($server);
-
         return Inertia::render('Voice/Speaking', [
             'servers' => $request->user()->servers,
-            'selectedServer' => $serverObj,
-            'selectedServer.users' => $serverObj->users,
-            'selectedServer.roles' => $serverObj->roles,
-            'selectedChannel' => Channel::find($channel),
-            'channels' => $serverObj->channels()->where('type', ChannelType::Voice)->get(),
-            'inviteCode' => $server.'#'.hash('xxh32', $server),
+            'selectedServer' => $server,
+            'selectedServer.users' => $server->users,
+            'selectedServer.roles' => $server->roles,
+            'selectedChannel' => $channel,
+            'channels' => $server->channels()->where('type', ChannelType::Voice)->get(),
+            'inviteCode' => $server->id.'#'.hash('xxh32', (string)$server->id),
         ]);
     }
 
-    public function wchannel(Request $request, int $server, int $channel): Response
+    public function wchannel(Request $request, Server $server, Channel $channel): Response
     {
-        $serverObj = Server::find($server);
-        $channelObj = Channel::with('whiteboard')->find($channel);
+        $channel->load('whiteboard');
 
-        if (! $channelObj->whiteboard) {
-            $channelObj->whiteboard()->create();
-            $channelObj->load('whiteboard');
+        if (! $channel->whiteboard) {
+            $channel->whiteboard()->create();
+            $channel->load('whiteboard');
         }
 
         return Inertia::render('Whiteboard/Whiteboarding')->with([
             'servers' => $request->user()->servers,
-            'selectedServer' => $serverObj,
-            'selectedServer.users' => $serverObj->users,
-            'selectedServer.roles' => $serverObj->roles,
-            'selectedChannel' => $channelObj,
-            'channels' => $serverObj->channels()->where('type', ChannelType::Whiteboard)->get(),
-            'inviteCode' => $server.'#'.hash('xxh32', $server),
+            'selectedServer' => $server,
+            'selectedServer.users' => $server->users,
+            'selectedServer.roles' => $server->roles,
+            'selectedChannel' => $channel,
+            'channels' => $server->channels()->where('type', ChannelType::Whiteboard)->get(),
+            'inviteCode' => $server->id.'#'.hash('xxh32', (string)$server->id),
         ]);
     }
 
-    public function whiteboard(Request $request, int $server): Response
+    public function whiteboard(Request $request, Server $server): Response
     {
-        $serverObj = Server::find($server);
-
         return Inertia::render('Whiteboard/Whiteboarding')->with([
             'servers' => $request->user()->servers,
-            'selectedServer' => $serverObj,
-            'selectedServer.users' => $serverObj->users,
-            'selectedServer.roles' => $serverObj->roles,
-            'channels' => $serverObj->channels()->where('type', ChannelType::Whiteboard)->get(),
-            'inviteCode' => $server.'#'.hash('xxh32', $server),
+            'selectedServer' => $server,
+            'selectedServer.users' => $server->users,
+            'selectedServer.roles' => $server->roles,
+            'channels' => $server->channels()->where('type', ChannelType::Whiteboard)->get(),
+            'inviteCode' => $server->id.'#'.hash('xxh32', (string)$server->id),
         ]);
     }
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -44,6 +44,10 @@ class HandleInertiaRequests extends Middleware
         return [
             ...parent::share($request),
             'user' => $user,
+            'flash' => [
+                'message' => fn () => $request->session()->get('message'),
+                'error' => fn () => $request->session()->get('error'),
+            ],
             'locale' => app()->getLocale(),
             'translations' => cache()->rememberForever('translations_'.app()->getLocale(), function () {
                 $locale = app()->getLocale();

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -49,12 +49,12 @@ class Channel extends Model
     public function resolveRouteBinding($value, $field = null)
     {
         $serverParam = request()->route('server');
-        
+
         $serverId = null;
-        if ($serverParam instanceof \App\Models\Server) {
+        if ($serverParam instanceof Server) {
             $serverId = $serverParam->id;
         } elseif (is_string($serverParam)) {
-            $server = \App\Models\Server::where('slug', $serverParam)->first();
+            $server = Server::where('slug', $serverParam)->first();
             if ($server) {
                 $serverId = $server->id;
             }
@@ -77,7 +77,7 @@ class Channel extends Model
                 $originalSlug = $slug;
                 $count = 1;
                 while (static::where('server_id', $channel->server_id)->where('slug', $slug)->exists()) {
-                    $slug = $originalSlug . '-' . $count;
+                    $slug = $originalSlug.'-'.$count;
                     $count++;
                 }
                 $channel->slug = $slug;

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Str;
 
 class Channel extends Model
 {
@@ -19,6 +20,7 @@ class Channel extends Model
         'name',
         'type',
         'server_id',
+        'slug',
     ];
 
     protected $dispatchesEvents = [
@@ -26,6 +28,62 @@ class Channel extends Model
         'updated' => ChannelEdited::class,
         'deleted' => ChannelDeleted::class,
     ];
+
+    protected $appends = ['route_key'];
+
+    public function getRouteKey()
+    {
+        return $this->slug;
+    }
+
+    public function getRouteKeyName()
+    {
+        return 'slug';
+    }
+
+    public function getRouteKeyAttribute()
+    {
+        return $this->slug;
+    }
+
+    public function resolveRouteBinding($value, $field = null)
+    {
+        $serverParam = request()->route('server');
+        
+        $serverId = null;
+        if ($serverParam instanceof \App\Models\Server) {
+            $serverId = $serverParam->id;
+        } elseif (is_string($serverParam)) {
+            $server = \App\Models\Server::where('slug', $serverParam)->first();
+            if ($server) {
+                $serverId = $server->id;
+            }
+        }
+
+        return $this->where('slug', $value)
+            ->when($serverId, function ($query, $serverId) {
+                return $query->where('server_id', $serverId);
+            })
+            ->firstOrFail();
+    }
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($channel) {
+            if (empty($channel->slug)) {
+                $slug = Str::slug($channel->name);
+                $originalSlug = $slug;
+                $count = 1;
+                while (static::where('server_id', $channel->server_id)->where('slug', $slug)->exists()) {
+                    $slug = $originalSlug . '-' . $count;
+                    $count++;
+                }
+                $channel->slug = $slug;
+            }
+        });
+    }
 
     public function messages(): HasMany
     {

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Spatie\Permission\Models\Permission;
+use Illuminate\Support\Str;
 
 class Server extends Model
 {
@@ -20,12 +21,53 @@ class Server extends Model
         'name',
         'description',
         'icon',
+        'slug',
     ];
 
     protected $dispatchesEvents = [
         'created' => ServerCreated::class,
         'updated' => ServerEdited::class,
     ];
+
+    protected $appends = ['route_key'];
+
+    public function getRouteKey()
+    {
+        return $this->slug;
+    }
+
+    public function getRouteKeyName()
+    {
+        return 'slug';
+    }
+
+    public function getRouteKeyAttribute()
+    {
+        return $this->slug;
+    }
+
+    public function resolveRouteBinding($value, $field = null)
+    {
+        return $this->where('slug', $value)->firstOrFail();
+    }
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($server) {
+            if (empty($server->slug)) {
+                $slug = Str::slug($server->name);
+                $originalSlug = $slug;
+                $count = 1;
+                while (static::where('slug', $slug)->exists()) {
+                    $slug = $originalSlug . '-' . $count;
+                    $count++;
+                }
+                $server->slug = $slug;
+            }
+        });
+    }
 
     public function users(): BelongsToMany
     {

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -10,8 +10,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
-use Spatie\Permission\Models\Permission;
 use Illuminate\Support\Str;
+use Spatie\Permission\Models\Permission;
 
 class Server extends Model
 {
@@ -61,7 +61,7 @@ class Server extends Model
                 $originalSlug = $slug;
                 $count = 1;
                 while (static::where('slug', $slug)->exists()) {
-                    $slug = $originalSlug . '-' . $count;
+                    $slug = $originalSlug.'-'.$count;
                     $count++;
                 }
                 $server->slug = $slug;

--- a/config/reverb.php
+++ b/config/reverb.php
@@ -30,7 +30,7 @@ return [
 
         'reverb' => [
             'host' => env('REVERB_SERVER_HOST', '0.0.0.0'),
-            'port' => env('REVERB_PORT', 8080),
+            'port' => env('REVERB_PORT', 3002),
             'hostname' => env('REVERB_HOST'),
             'options' => [
                 'tls' => [],

--- a/database/migrations/2026_06_26_203758_add_slugs_to_servers_and_channels.php
+++ b/database/migrations/2026_06_26_203758_add_slugs_to_servers_and_channels.php
@@ -1,0 +1,75 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('servers', function (Blueprint $table) {
+            $table->string('slug')->nullable()->unique();
+        });
+
+        Schema::table('channels', function (Blueprint $table) {
+            $table->string('slug')->nullable();
+            $table->unique(['server_id', 'slug']);
+        });
+
+        // Generate slugs for existing servers
+        $servers = DB::table('servers')->get();
+        foreach ($servers as $server) {
+            $slug = Str::slug($server->name);
+            $originalSlug = $slug;
+            $count = 1;
+            while (DB::table('servers')->where('slug', $slug)->exists()) {
+                $slug = $originalSlug . '-' . $count;
+                $count++;
+            }
+            DB::table('servers')->where('id', $server->id)->update(['slug' => $slug]);
+        }
+
+        // Generate slugs for existing channels
+        $channels = DB::table('channels')->get();
+        foreach ($channels as $channel) {
+            $slug = Str::slug($channel->name);
+            $originalSlug = $slug;
+            $count = 1;
+            while (DB::table('channels')->where('server_id', $channel->server_id)->where('slug', $slug)->exists()) {
+                $slug = $originalSlug . '-' . $count;
+                $count++;
+            }
+            DB::table('channels')->where('id', $channel->id)->update(['slug' => $slug]);
+        }
+
+        // Make columns non-nullable after filling data
+        Schema::table('servers', function (Blueprint $table) {
+            $table->string('slug')->nullable(false)->change();
+        });
+
+        Schema::table('channels', function (Blueprint $table) {
+            $table->string('slug')->nullable(false)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('channels', function (Blueprint $table) {
+            $table->dropUnique(['server_id', 'slug']);
+            $table->dropColumn('slug');
+        });
+
+        Schema::table('servers', function (Blueprint $table) {
+            $table->dropColumn('slug');
+        });
+    }
+};

--- a/database/migrations/2026_06_26_203758_add_slugs_to_servers_and_channels.php
+++ b/database/migrations/2026_06_26_203758_add_slugs_to_servers_and_channels.php
@@ -2,8 +2,8 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
 return new class extends Migration
@@ -29,7 +29,7 @@ return new class extends Migration
             $originalSlug = $slug;
             $count = 1;
             while (DB::table('servers')->where('slug', $slug)->exists()) {
-                $slug = $originalSlug . '-' . $count;
+                $slug = $originalSlug.'-'.$count;
                 $count++;
             }
             DB::table('servers')->where('id', $server->id)->update(['slug' => $slug]);
@@ -42,7 +42,7 @@ return new class extends Migration
             $originalSlug = $slug;
             $count = 1;
             while (DB::table('channels')->where('server_id', $channel->server_id)->where('slug', $slug)->exists()) {
-                $slug = $originalSlug . '-' . $count;
+                $slug = $originalSlug.'-'.$count;
                 $count++;
             }
             DB::table('channels')->where('id', $channel->id)->update(['slug' => $slug]);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
         "@vue/server-renderer": "^3.5.39",
         "@y/websocket-server": "^0.1.5",
         "autoprefixer": "^10.5.2",
-        "axios": "^1.18.1",
         "daisyui": "^5.5.23",
         "eslint": "^10.5.0",
         "eslint-config-prettier": "^10.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,9 +42,6 @@ importers:
       autoprefixer:
         specifier: ^10.5.2
         version: 10.5.2(postcss@8.5.15)
-      axios:
-        specifier: ^1.18.1
-        version: 1.18.1
       daisyui:
         specifier: ^5.5.23
         version: 5.5.23
@@ -2142,6 +2139,7 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   ajv@6.15.0:
     dependencies:
@@ -2156,7 +2154,8 @@ snapshots:
 
   async-limiter@1.0.1: {}
 
-  asynckit@0.4.0: {}
+  asynckit@0.4.0:
+    optional: true
 
   autoprefixer@10.5.2(postcss@8.5.15):
     dependencies:
@@ -2176,6 +2175,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
       - supports-color
+    optional: true
 
   bad-words@4.0.0:
     dependencies:
@@ -2205,12 +2205,14 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+    optional: true
 
   caniuse-lite@1.0.30001799: {}
 
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+    optional: true
 
   create-require@1.1.1: {}
 
@@ -2232,7 +2234,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  delayed-stream@1.0.0: {}
+  delayed-stream@1.0.0:
+    optional: true
 
   detect-libc@2.1.2: {}
 
@@ -2243,6 +2246,7 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+    optional: true
 
   electron-to-chromium@1.5.378: {}
 
@@ -2253,13 +2257,16 @@ snapshots:
 
   entities@7.0.1: {}
 
-  es-define-property@1.0.1: {}
+  es-define-property@1.0.1:
+    optional: true
 
-  es-errors@1.3.0: {}
+  es-errors@1.3.0:
+    optional: true
 
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
+    optional: true
 
   es-set-tostringtag@2.1.0:
     dependencies:
@@ -2267,6 +2274,7 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.4
+    optional: true
 
   es-toolkit@1.48.1: {}
 
@@ -2415,7 +2423,8 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.16.0: {}
+  follow-redirects@1.16.0:
+    optional: true
 
   form-data@4.0.6:
     dependencies:
@@ -2424,13 +2433,15 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.4
       mime-types: 2.1.35
+    optional: true
 
   fraction.js@5.3.4: {}
 
   fsevents@2.3.3:
     optional: true
 
-  function-bind@1.1.2: {}
+  function-bind@1.1.2:
+    optional: true
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -2444,11 +2455,13 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.4
       math-intrinsics: 1.1.0
+    optional: true
 
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.2
+    optional: true
 
   glob-parent@6.0.2:
     dependencies:
@@ -2456,19 +2469,23 @@ snapshots:
 
   globals@17.7.0: {}
 
-  gopd@1.2.0: {}
+  gopd@1.2.0:
+    optional: true
 
   graceful-fs@4.2.11: {}
 
-  has-symbols@1.1.0: {}
+  has-symbols@1.1.0:
+    optional: true
 
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
+    optional: true
 
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
+    optional: true
 
   https-proxy-agent@5.0.1:
     dependencies:
@@ -2476,6 +2493,7 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   ignore@5.3.2: {}
 
@@ -2594,13 +2612,16 @@ snapshots:
 
   make-error@1.3.6: {}
 
-  math-intrinsics@1.1.0: {}
+  math-intrinsics@1.1.0:
+    optional: true
 
-  mime-db@1.52.0: {}
+  mime-db@1.52.0:
+    optional: true
 
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+    optional: true
 
   minimatch@10.2.5:
     dependencies:
@@ -2664,7 +2685,8 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  proxy-from-env@2.1.0: {}
+  proxy-from-env@2.1.0:
+    optional: true
 
   punycode@2.3.1: {}
 

--- a/resources/js/Components/ChannelSelectBar.vue
+++ b/resources/js/Components/ChannelSelectBar.vue
@@ -10,7 +10,6 @@ import {ref} from "vue";
 import {Perms, PermType, Role, Server} from "@/types";
 import {bigIntToPerms} from "@/bootstrap";
 import ConfirmDialog from '@/Components/ConfirmDialog.vue';
-import axios from "axios";
 import { BsChatText, BsDoorOpen, BsEasel, BsGearFill } from 'vue-icons-plus/bs';
 import { RiChatVoiceLine } from 'vue-icons-plus/ri';
 
@@ -28,9 +27,8 @@ function leaveServer() {
         return;
     }
 
-    axios.delete(
-        leave.url(selectedServer.id)).then(() => {
-        router.reload();
+    router.delete(leave.url(selectedServer.route_key), {
+        onSuccess: () => router.reload()
     });
 }
 
@@ -52,7 +50,7 @@ function leaveServer() {
                 </div>
             </ConfirmDialog>
 
-            <Link :href="text.url(selectedServer?.id)">
+            <Link :href="text.url(selectedServer?.route_key)">
                 <button
                     :class="{ 'border-b-2 border-base-content text-base-content': $page.url.includes('/text') }"
                     class="flex flex-col items-center justify-center gap-1 p-2 relative"
@@ -66,7 +64,7 @@ function leaveServer() {
             <!-- Server settings -->
             <Link
                 v-if="perms.hasAny([PermType.CAN_MANAGE_SERVER, PermType.CAN_MANAGE_ROLE, PermType.CAN_MANAGE_MEMBERS])"
-                :href="server.url(selectedServer?.id)"
+                :href="server.url(selectedServer?.route_key)"
                 class="right-2 mt-3 absolute btn btn-ghost tooltip tooltip-left" data-tip="Server settings">
                 <button
                     class="flex items-center justify-center h-10 w-auto my-auto"
@@ -75,7 +73,7 @@ function leaveServer() {
                 </button>
             </Link>
 
-            <Link :href="voice.url(selectedServer?.id)">
+            <Link :href="voice.url(selectedServer?.route_key)">
                 <button
                     :class="{ 'border-b-2 border-base-content text-base-content': $page.url.includes('/voice') }"
                     class="flex flex-col items-center justify-center gap-1 p-2 relative"
@@ -87,7 +85,7 @@ function leaveServer() {
                 </button>
             </Link>
 
-            <Link :href="whiteboard.url(selectedServer?.id!)">
+            <Link :href="whiteboard.url(selectedServer?.route_key!)">
                 <button
                     :class="{'border-b-2 border-base-content text-base-content': $page.url.includes('/whiteboard') }"
                     class="flex flex-col items-center justify-center gap-1 p-2 relative">

--- a/resources/js/Components/ServerSelectBar.vue
+++ b/resources/js/Components/ServerSelectBar.vue
@@ -7,7 +7,6 @@ import {Link, router, useForm, usePage} from "@inertiajs/vue3";
 import ApplicationLogo from "@/Components/ApplicationLogo.vue";
 import {computed, ref} from 'vue';
 import {baseUrl, defaultIcon, joinServer} from "@/bootstrap";
-import axios from "axios";
 import {Server} from "@/types";
 import ErrorAlert from "@/Components/ErrorAlert.vue";
 import { RiMoonClearFill } from 'vue-icons-plus/ri';
@@ -37,21 +36,19 @@ const loading = ref(false);
 const createServer = async () => {
     if (loading.value) return;
     loading.value = true;
-    axios.postForm(create.url(), form.data())
-        .then(() => {
+    form.post(create.url(), {
+        onSuccess: () => {
             serverModal.value?.close();
             router.reload({only: ['servers', 'user']});
             form.reset();
-        })
-        .catch((err) => {
-            for (const [name, errors] of (Object.entries(err.response.data.errors) as [name: string, errors: string[]][])) {
-                errors.forEach(error => form.setError(name as "description" | "icon" | "name", error))
-            }
-            console.error('Error creating server:', err);
-        })
-        .finally(() => {
+        },
+        onError: (errors) => {
+            console.error('Error creating server:', errors);
+        },
+        onFinish: () => {
             loading.value = false;
-        });
+        }
+    });
 };
 
 const icon = ref<string | null>(null);
@@ -77,7 +74,7 @@ const updateIcon = (val: File) => {
             class="navbar-center w-3/5 overflow-x-auto overflow-y-hidden whitespace-nowrap flex justify-center items-center">
             <div v-for="server in servers" :key="server.id">
                 <div class="hidden space-x-5 sm:-my-px sm:m-3 sm:flex">
-                    <Link :href="serverRoute.url(server.id)">
+                    <Link :href="serverRoute.url(server.route_key)">
                         <div :data-tip="server.name" class="tooltip tooltip-bottom">
                             <div class="btn btn-ghost btn-circle avatar">
                                 <div class="w-14 rounded-full">

--- a/resources/js/Components/SettingsHeader.vue
+++ b/resources/js/Components/SettingsHeader.vue
@@ -27,18 +27,18 @@ const {selectedServer} = defineProps<{
         <div class="flex space-x-6">
             <Link
                 v-if="perms.has([PermType.CAN_MANAGE_SERVER])"
-                :href="server.url(selectedServer?.id)"
+                :href="server.url(selectedServer?.route_key)"
                 class="text-lg text-base-content transition-all duration-300 ease-in-out hover:bg-base-200 hover:pl-6 hover:pr-6 p-2 rounded-lg btn btn-neutral">
                 Server
             </Link>
             <Link
-                v-if="perms.has([PermType.CAN_MANAGE_ROLE])" :href="role.url(selectedServer?.id)"
+                v-if="perms.has([PermType.CAN_MANAGE_ROLE])" :href="role.url(selectedServer?.route_key)"
                 class="text-lg text-base-content transition-all duration-300 ease-in-out hover:bg-base-200 hover:pl-6 hover:pr-6 p-2 rounded-lg btn btn-neutral">
                 Roles
             </Link>
             <Link
                 v-if="perms.has([PermType.CAN_MANAGE_MEMBERS])"
-                :href="members.url(selectedServer?.id)"
+                :href="members.url(selectedServer?.route_key)"
                 class="text-lg text-base-content transition-all duration-300 ease-in-out hover:bg-base-200 hover:pl-6 hover:pr-6 p-2 rounded-lg btn btn-neutral">
                 Members
             </Link>

--- a/resources/js/Components/TextSelectBar.vue
+++ b/resources/js/Components/TextSelectBar.vue
@@ -5,7 +5,6 @@ import { create, deleteMethod, edit } from '@/routes/channel';
 import { channel as channelRoute } from '@/routes/home/text';
 import {Link, router, useForm, usePage} from "@inertiajs/vue3";
 import {ref} from "vue";
-import axios from "axios";
 import {Channel, ChannelType, Perms, PermType, Role, Server} from "@/types";
 import ErrorAlert from "@/Components/ErrorAlert.vue";
 import ConfirmDialog from "@/Components/ConfirmDialog.vue";
@@ -36,7 +35,7 @@ const openModal = (channel?: Channel) => {
     if (channel) {
         isEditing.value = true;
         form.name = channel?.name || '';
-        editCurrent.value = () => editChannel(channel.id);
+        editCurrent.value = () => editChannel(channel.route_key);
     } else {
         isEditing.value = false;
         form.name = '';
@@ -47,44 +46,42 @@ const openModal = (channel?: Channel) => {
 const createChannel = async () => {
     if (loading.value) return;
     loading.value = true;
-    axios.postForm(create.url(selectedServer!.id), form.data())
-        .then(() => {
+    form.post(create.url(selectedServer!.route_key), {
+        onSuccess: () => {
             channelModal.value?.close();
             router.reload();
             form.reset();
-        })
-        .catch((err) => {
-            console.error('Error creating server:', err);
-        })
-        .finally(() => {
+        },
+        onError: (errors) => {
+            console.error('Error creating server:', errors);
+        },
+        onFinish: () => {
             loading.value = false;
-        });
-};
-
-const deleteChannel = async (channelId: number) => {
-    console.log(channelId)
-    axios.delete(deleteMethod.url(channelId)).then(() => {
-        router.reload()
+        }
     });
 };
 
-const editChannel = async (channelId: number) => {
-    console.log(channelId)
+const deleteChannel = async (channel: Channel) => {
+    router.delete(deleteMethod.url({server: selectedServer!.route_key, channel: channel.route_key}));
+};
+
+const editChannel = async (channelKey: string) => {
     if (loading.value) return;
     loading.value = true;
 
-    axios.patch(edit.url(channelId), form.data())
-        .then(() => {
+    form.patch(edit.url({server: selectedServer!.route_key, channel: channelKey}), {
+        onSuccess: () => {
             channelModal.value?.close();
-            router.reload()
+            router.reload();
             form.reset();
-        })
-        .catch((err) => {
-            console.error('Error creating server:', err);
-        })
-        .finally(() => {
+        },
+        onError: (errors) => {
+            console.error('Error editing server:', errors);
+        },
+        onFinish: () => {
             loading.value = false;
-        });
+        }
+    });
 };
 
 if (selectedServer) {
@@ -110,7 +107,7 @@ if (selectedServer) {
                 v-if="perms.has([PermType.CAN_MANAGE_CHANNEL, PermType.CAN_DELETE_CHANNEL])"
                 class="indicator-item indicator-top absolute hidden group-hover:block">
                 <ConfirmDialog
-                    :confirm="() => deleteChannel(channel.id)"
+                    :confirm="() => deleteChannel(channel)"
                     :description="`Are you sure you want to delete ${channel.name} channel?`"
                     class-name="indicator-item badge badge-error h-auto w-auto p-0.5"
                     title="Delete Channel"
@@ -128,7 +125,7 @@ if (selectedServer) {
                 </button>
             </div>
 
-            <Link :href="channelRoute.url({server : selectedServer?.id!, channel : channel.id})">
+            <Link :href="channelRoute.url({server : selectedServer?.route_key!, channel : channel.route_key})">
                 <button
                     :class="{'bg-base-300 text-base-content' : selectedChannel?.id === channel.id}"
                     class="btn btn-outline btn-sm">

--- a/resources/js/Components/WhiteboardSelectBar.vue
+++ b/resources/js/Components/WhiteboardSelectBar.vue
@@ -5,7 +5,6 @@ import { create, deleteMethod, edit } from '@/routes/channel';
 import { channel as channelRoute } from '@/routes/home/whiteboard';
 import {Link, router, useForm, usePage} from "@inertiajs/vue3";
 import {ref} from "vue";
-import axios from "axios";
 import {Channel, ChannelType, Perms, PermType, Role, Server} from "@/types";
 import ErrorAlert from "@/Components/ErrorAlert.vue";
 import ConfirmDialog from "@/Components/ConfirmDialog.vue";
@@ -36,7 +35,7 @@ const openModal = (channel?: Channel) => {
     if (channel) {
         isEditing.value = true;
         form.name = channel?.name || '';
-        editCurrent.value = () => editChannel(channel.id);
+        editCurrent.value = () => editChannel(channel.route_key);
     } else {
         isEditing.value = false;
         form.name = '';
@@ -47,42 +46,42 @@ const openModal = (channel?: Channel) => {
 const createChannel = async () => {
     if (loading.value) return;
     loading.value = true;
-    axios.postForm(create.url(selectedServer!.id), form.data())
-        .then(() => {
+    form.post(create.url(selectedServer!.route_key), {
+        onSuccess: () => {
             channelModal.value?.close();
             router.reload();
             form.reset();
-        })
-        .catch((err) => {
-            console.error('Error creating server:', err);
-        })
-        .finally(() => {
+        },
+        onError: (errors) => {
+            console.error('Error creating channel:', errors);
+        },
+        onFinish: () => {
             loading.value = false;
-        });
-};
-
-const deleteChannel = async (channelId: number) => {
-    axios.delete(deleteMethod.url(channelId)).then(() => {
-        router.reload()
+        }
     });
 };
 
-const editChannel = async (channelId: number) => {
+const deleteChannel = async (channel: Channel) => {
+    router.delete(deleteMethod.url({server: selectedServer!.route_key, channel: channel.route_key}));
+};
+
+const editChannel = async (channelKey: string) => {
     if (loading.value) return;
     loading.value = true;
 
-    axios.patch(edit.url(channelId), form.data())
-        .then(() => {
+    form.patch(edit.url({server: selectedServer!.route_key, channel: channelKey}), {
+        onSuccess: () => {
             channelModal.value?.close();
-            router.reload()
+            router.reload();
             form.reset();
-        })
-        .catch((err) => {
-            console.error('Error editing channel:', err);
-        })
-        .finally(() => {
+        },
+        onError: (errors) => {
+            console.error('Error editing channel:', errors);
+        },
+        onFinish: () => {
             loading.value = false;
-        });
+        }
+    });
 };
 
 if (selectedServer) {
@@ -108,7 +107,7 @@ if (selectedServer) {
                 v-if="perms.has([PermType.CAN_MANAGE_CHANNEL, PermType.CAN_DELETE_CHANNEL])"
                 class="indicator-item indicator-top absolute hidden group-hover:block">
                 <ConfirmDialog
-                    :confirm="() => deleteChannel(channel.id)"
+                    :confirm="() => deleteChannel(channel)"
                     :description="`Are you sure you want to delete ${channel.name} whiteboard channel?`"
                     class-name="indicator-item badge badge-error h-auto w-auto p-0.5"
                     title="Delete Channel"
@@ -126,7 +125,7 @@ if (selectedServer) {
                 </button>
             </div>
 
-            <Link :href="channelRoute.url({server : selectedServer?.id!, channel : channel.id})">
+            <Link :href="channelRoute.url({server : selectedServer?.route_key!, channel : channel.route_key})">
                 <button
                     :class="{'bg-base-300 text-base-content' : selectedChannel?.id === channel.id}"
                     class="btn btn-outline btn-sm">

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -60,6 +60,17 @@ if (selectedServer) {
             <slot/>
         </main>
 
+        <div v-if="$page.props.flash?.message" class="toast toast-top toast-end z-50">
+            <div class="alert alert-success">
+                <span>{{ $page.props.flash.message }}</span>
+            </div>
+        </div>
+        <div v-if="$page.props.flash?.error" class="toast toast-top toast-end z-50">
+            <div class="alert alert-error">
+                <span>{{ $page.props.flash.error }}</span>
+            </div>
+        </div>
+
         <footer v-if="selectedServer">
             <div v-if="inviteCode !== undefined && perms.has([PermType.CAN_INVITE])" class="toast truncate mb-16">
                 <div

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -60,7 +60,7 @@ if (selectedServer) {
             <slot/>
         </main>
 
-        <footer v-if="$page.url.match(/\/home\/\d+/)">
+        <footer v-if="selectedServer">
             <div v-if="inviteCode !== undefined && perms.has([PermType.CAN_INVITE])" class="toast truncate mb-16">
                 <div
                     class="alert transition-all delay-300 ease-in-out items-center justify-center gap-0 bg-base-100"

--- a/resources/js/Pages/Settings/Members.vue
+++ b/resources/js/Pages/Settings/Members.vue
@@ -8,7 +8,6 @@ import { removeUser as server_removeUser } from '@/routes/server';
 import {Link, router, usePage} from "@inertiajs/vue3";
 import {Perms, PermType, Role, Server, User} from "@/types";
 import SettingsHeader from "@/Components/SettingsHeader.vue";
-import axios from "axios";
 import ConfirmDialog from "@/Components/ConfirmDialog.vue";
 import {ref} from "vue";
 import {bigIntToPerms} from "@/bootstrap";
@@ -32,20 +31,21 @@ const {selectedServer} = defineProps<{
 
 const toggleRole = (roleId: number, userId: number, state: boolean) => {
     if (state) {
-        axios.post(addUser.url({role: roleId, user: userId})).then(() => {
-            router.reload({only: ['selected_server']});
-        })
+        router.post(addUser.url({role: roleId, user: userId}), {}, {
+            onSuccess: () => router.reload({only: ['selected_server']})
+        });
     } else {
-        axios.delete(roles_removeUser.url({role: roleId, user: userId})).then(() => {
-            router.reload({only: ['selected_server']});
-        })
+        router.delete(roles_removeUser.url({role: roleId, user: userId}), {
+            onSuccess: () => router.reload({only: ['selected_server']})
+        });
     }
 };
 
 const kickMember = (userId: number) =>
-    axios.delete(server_removeUser.url(selectedServer.id), {data: {'user_id': userId}}).then(() =>
-        router.reload({only: ['selected_server']})
-    )
+    router.delete(server_removeUser.url(selectedServer.route_key), {
+        data: {'user_id': userId},
+        onSuccess: () => router.reload({only: ['selected_server']})
+    });
 
 
 
@@ -58,7 +58,7 @@ const kickMember = (userId: number) =>
             <SettingsHeader :selected-server/>
 
             <div class="flex justify-end mb-6 space-x-4">
-                <Link :href="server.url(selectedServer?.id)" class="btn btn-neutral">
+                <Link :href="server.url(selectedServer?.route_key)" class="btn btn-neutral">
                     Cancel
                 </Link>
             </div>

--- a/resources/js/Pages/Settings/Role.vue
+++ b/resources/js/Pages/Settings/Role.vue
@@ -1,11 +1,10 @@
 <script lang="ts" setup>
-import { usePerms } from '@/bootstrap';
+import { usePerms, fetchJson } from '@/bootstrap';
 
 import { server } from '@/routes/home';
 import { create, deleteMethod, edit, index } from '@/routes/roles';
 import {ref} from 'vue';
 import {Link, usePage} from '@inertiajs/vue3';
-import axios, {AxiosResponse} from 'axios';
 import {Perms, PermType, Role, Server} from "@/types";
 import SettingsHeader from "@/Components/SettingsHeader.vue";
 import {bigIntToPerms} from "@/bootstrap";
@@ -32,7 +31,7 @@ const isModalOpen = ref(false);
 
 const fetchRoles = async () => {
     try {
-        const response: AxiosResponse<Role[] | null> = await axios.get(index.url(selectedServer?.id));
+        const response = await fetchJson(index.url(selectedServer?.route_key));
         roles.value = response.data ?? []; // Default to an empty array if undefined
         // Sort roles by importance
         roles.value.sort((a, b) => a.importance - b.importance);
@@ -59,7 +58,11 @@ const updateRole = async () => {
     const currentEditingRole = editingRole.value;
 
     if (currentEditingRole) {
-        const response = await axios.patch(edit.url(currentEditingRole.id), newRole.value);
+        const response = await fetchJson(edit.url(currentEditingRole.id), {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(newRole.value)
+        });
 
         const index = roles.value.findIndex(r => r.id === currentEditingRole.id);
         roles.value[index] = response.data.role;
@@ -79,11 +82,15 @@ const addRole = async () => {
             newRole.value.importance = maxImportance + 1;
         }
 
-        await axios.post(create.url(selectedServer?.id), {
-            name: newRole.value.name,
-            color: newRole.value.color,
-            perms: newRole.value.perms,
-            importance: newRole.value.importance,
+        await fetchJson(create.url(selectedServer?.route_key), {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                name: newRole.value.name,
+                color: newRole.value.color,
+                perms: newRole.value.perms,
+                importance: newRole.value.importance,
+            })
         });
 
         closeModal();
@@ -95,14 +102,18 @@ const addRole = async () => {
 
 const deleteRole = async (role: Role) => {
     try {
-        await axios.delete(deleteMethod.url(role.id));
+        await fetchJson(deleteMethod.url(role.id), { method: 'DELETE' });
 
         roles.value = roles.value.filter(r => r.id !== role.id);
 
         roles.value.forEach(r => {
             if (r.importance > role.importance) {
                 r.importance -= 1;
-                axios.patch(edit.url(r.id), {importance: r.importance});
+                fetchJson(edit.url(r.id), {
+                    method: 'PATCH',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({importance: r.importance})
+                });
             }
         });
 
@@ -159,8 +170,16 @@ const changeImportance = async (role: Role, direction: number) => {
         role.importance = swapRole.importance;
         swapRole.importance = tempImportance;
 
-        await axios.patch(edit.url(role.id), {importance: role.importance});
-        await axios.patch(edit.url(swapRole.id), {importance: swapRole.importance});
+        await fetchJson(edit.url(role.id), {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({importance: role.importance})
+        });
+        await fetchJson(edit.url(swapRole.id), {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({importance: swapRole.importance})
+        });
     }
 
     roles.value.sort((a, b) => a.importance - b.importance);
@@ -175,7 +194,7 @@ const changeImportance = async (role: Role, direction: number) => {
             <!-- Navbar for Navigation -->
             <SettingsHeader :selected-server/>
             <div class="flex justify-end mb-6 space-x-4">
-                <Link :href="server.url(selectedServer?.id)" class="btn btn-neutral">
+                <Link :href="server.url(selectedServer?.route_key)" class="btn btn-neutral">
                     Cancel
                 </Link>
             </div>

--- a/resources/js/Pages/Settings/Server.vue
+++ b/resources/js/Pages/Settings/Server.vue
@@ -41,7 +41,7 @@ function handleSave() {
         return;
     }
     form.clearErrors(); // Clear any existing errors
-    form.post(update.url(selectedServer!.id), {
+    form.post(update.url(selectedServer!.route_key), {
         onSuccess: () => {
             router.reload(); // This will reload the current Inertia page without a full page reload
         },
@@ -49,7 +49,7 @@ function handleSave() {
 }
 
 function deleteServer() {
-    router.delete(destroy.url(selectedServer!.id), {
+    router.delete(destroy.url(selectedServer!.route_key), {
         onSuccess: () => {
             router.visit('/home');
         },
@@ -72,7 +72,7 @@ function deleteServer() {
                     @click="handleSave">
                     Save Changes
                 </button>
-                <Link :href="serverRoute.url(selectedServer!.id)" class="btn btn-neutral">
+                <Link :href="serverRoute.url(selectedServer!.route_key)" class="btn btn-neutral">
                     Cancel
                 </Link>
             </div>

--- a/resources/js/Pages/Text/Texting.vue
+++ b/resources/js/Pages/Text/Texting.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { usePerms } from '@/bootstrap';
+import { usePerms, fetchJson } from '@/bootstrap';
 
 import { create, deleteMethod, edit } from '@/routes/message';
 import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout.vue";
@@ -7,7 +7,6 @@ import TextSelectBar from "@/Components/TextSelectBar.vue";
 import {router, useForm, usePage} from "@inertiajs/vue3";
 import echo from "@/echo";
 import {Channel, Message, MessageType, Perms, PermType, Role, Server} from "@/types";
-import axios from "axios";
 import {nextTick, onMounted, onUpdated, ref, watch} from "vue";
 import {baseUrl, bigIntToPerms, defaultIcon} from "@/bootstrap";
 import ConfirmDialog from "@/Components/ConfirmDialog.vue";
@@ -84,19 +83,24 @@ const createMessage = async () => {
         if (typeof (form.mdata) === "string") {
             form.type = MessageType.Text;
         }
-        if ((form.mdata as string).length > 500) {
+        if (typeof (form.mdata) === "string" && form.mdata.length > 500) {
             hasError.value = true;
             return;
         }
-        axios.postForm(create.url(selectedChannel!.id), form.data())
-            .then(() => {
+        
+        form.post(create.url({server: selectedServer!.route_key, channel: selectedChannel!.route_key}), {
+            preserveScroll: true,
+            onSuccess: () => {
                 clearFile();
                 hasError.value = false;
-            });
-        await new Promise((resolve) => setTimeout(resolve, 500))
+            },
+            onFinish: () => {
+                loading.value = false;
+            }
+        });
+        
     } catch (error) {
         console.error('Error sending message:', error);
-    } finally {
         loading.value = false;
     }
 };
@@ -119,15 +123,19 @@ watch(
 );
 
 const deleteMessage = async (messageId: number) => {
-    await axios.delete(deleteMethod.url(messageId));
+    router.delete(deleteMethod.url(messageId), { preserveScroll: true });
 };
 
 const editMessage = async () => {
     if (messageIdToEdit.value !== null) {
-        await axios.patch(edit.url(messageIdToEdit.value), {mdata: form.mdata});
-        messageModal.value?.close();
-        form.reset();
-        router.reload();
+        router.patch(edit.url(messageIdToEdit.value), {mdata: form.mdata}, {
+            preserveScroll: true,
+            onSuccess: () => {
+                messageModal.value?.close();
+                form.reset();
+                router.reload();
+            }
+        });
     }
 };
 
@@ -156,7 +164,7 @@ const uploadFile = (val: File) => {
     <AuthenticatedLayout :invite-code :selected-server :servers>
         <TextSelectBar :channels :selected-channel :selected-server/>
         <div
-            v-if="$page.url.match(/\/text\/\d+/)"
+            v-if="selectedChannel"
             class="w-2/3 h-[calc(100vh-64px-80px-64px-80px-16px)] bg-base-100 m-5 rounded-lg mx-auto mt-3 flex flex-col"
         >
             <div ref="messageContainer" class="overflow-y-auto flex-grow p-3 mx-5 mt-5">

--- a/resources/js/Pages/Voice/Speaking.vue
+++ b/resources/js/Pages/Voice/Speaking.vue
@@ -4,7 +4,6 @@ import {baseUrl, defaultIcon, usePerms} from '@/bootstrap';
 import {create, deleteMethod, edit} from '@/routes/channel';
 import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout.vue";
 import {router, useForm} from "@inertiajs/vue3";
-import axios from "axios";
 import {ref} from "vue";
 import {Channel, ChannelType, PermType, Server} from "@/types";
 import ConfirmDialog from "@/Components/ConfirmDialog.vue";
@@ -33,7 +32,7 @@ const openModal = (channel?: Channel) => {
     if (channel) {
         isEditing.value = true;
         form.name = channel?.name || '';
-        editCurrent.value = () => editText(channel.id);
+        editCurrent.value = () => editText(channel.id, channel.route_key);
     } else {
         isEditing.value = false;
         form.name = '';
@@ -42,22 +41,24 @@ const openModal = (channel?: Channel) => {
 };
 
 const createText = async () => {
-    axios.postForm(create.url(selectedServer!.id), form.data()).then(() => {
-        channelModal.value?.close();
-        router.reload()
+    form.post(create.url(selectedServer!.route_key), {
+        onSuccess: () => {
+            channelModal.value?.close();
+            router.reload();
+        }
     });
 };
 
-const deleteText = async (channelId: number) => {
-    axios.delete(deleteMethod.url(channelId)).then(() => {
-        router.reload()
-    });
+const deleteText = async (channel: Channel) => {
+    router.delete(deleteMethod.url({server: selectedServer!.route_key, channel: channel.route_key}));
 };
 
-const editText = async (channelId: number) => {
-    axios.patch(edit.url(channelId), form.data()).then(() => {
-        channelModal.value?.close();
-        router.reload()
+const editText = async (channelId: number, channelKey: string) => {
+    form.patch(edit.url({server: selectedServer!.route_key, channel: channelKey}), {
+        onSuccess: () => {
+            channelModal.value?.close();
+            router.reload();
+        }
     });
 };
 
@@ -109,7 +110,7 @@ const leaveChannel = async () => {
                     v-if="perms.has([PermType.CAN_MANAGE_CHANNEL, PermType.CAN_DELETE_CHANNEL])"
                     class="indicator-item indicator-top absolute hidden group-hover:block">
                     <ConfirmDialog
-                        :confirm="() => deleteText(channel.id)"
+                        :confirm="() => deleteText(channel)"
                         :description="`Are you sure you want to delete ${channel.name} channel?`"
                         class-name="indicator-item badge badge-error h-auto w-auto p-0.5"
                         title="Delete Channel"

--- a/resources/js/Pages/Whiteboard/WhiteboardBoard.vue
+++ b/resources/js/Pages/Whiteboard/WhiteboardBoard.vue
@@ -4,7 +4,7 @@ import * as Y from 'yjs';
 import {WebsocketProvider} from 'y-websocket';
 import {Whiteboard as WhiteboardType} from '@/types';
 import {save} from '@/routes/whiteboard';
-import axios from 'axios';
+import { fetchJson } from '@/bootstrap';
 import { MdAdsClick, MdHorizontalRule, MdOutlineCircle, MdOutlineDelete, MdOutlineFormatColorFill, MdOutlineRectangle, MdRedo, MdUndo } from 'vue-icons-plus/md';
 import { BsEraser } from 'vue-icons-plus/bs';
 import { HiPencil } from 'vue-icons-plus/hi';
@@ -89,7 +89,7 @@ const startHeartbeat = () => {
         }
         const start = Date.now();
         try {
-            await axios.get('/up');
+            await fetchJson('/up');
             latency.value = Date.now() - start;
         } catch (e) {
             console.error("Heartbeat failed", e);
@@ -377,7 +377,11 @@ const updateTransformer = () => {
 const saveState = async () => {
     const state = JSON.stringify(Object.fromEntries(yshapes.entries()));
     try {
-        await axios.post(save.url(props.whiteboard.id), {state});
+        await fetchJson(save.url(props.whiteboard.id), {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({state})
+        });
     } catch (e) {
         console.error("Failed to save whiteboard state", e);
     }

--- a/resources/js/Pages/Whiteboard/Whiteboarding.vue
+++ b/resources/js/Pages/Whiteboard/Whiteboarding.vue
@@ -19,7 +19,7 @@ const {selectedChannel, selectedServer} = defineProps<{
         <WhiteboardSelectBar :channels :selected-channel :selected-server/>
 
         <div
-            v-if="$page.url.match(/\/whiteboard\/\d+/)"
+            v-if="selectedChannel"
             class="flex-grow flex flex-col overflow-hidden h-[calc(100vh-64px-64px)]"
         >
             <WhiteboardBoard v-if="selectedChannel?.whiteboard" :whiteboard="selectedChannel.whiteboard" />

--- a/resources/js/bootstrap.ts
+++ b/resources/js/bootstrap.ts
@@ -1,14 +1,9 @@
 import {addUser} from '@/routes/server';
-import axios, {AxiosError} from 'axios';
 import './echo';
 import {router, usePage} from "@inertiajs/vue3";
 import {Perms, Role, Server} from "@/types";
 import {computed} from 'vue';
 
-if (typeof window !== 'undefined') {
-    window.axios = axios;
-    window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
-}
 export const defaultIcon = "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcS78CXwhRL-71jDHotN6WOTp9dC1RWPQEAJUA&s";
 
 export const baseUrl = typeof window !== 'undefined' ? window.location.origin : '';
@@ -49,14 +44,49 @@ export const usePerms = () => {
     });
 };
 
+export const fetchJson = async (url: string, options: RequestInit = {}) => {
+    const xsrfTokenMatch = document.cookie.match(new RegExp('(^| )XSRF-TOKEN=([^;]+)'));
+    const xsrfToken = xsrfTokenMatch ? decodeURIComponent(xsrfTokenMatch[2]) : '';
+
+    const headers: Record<string, string> = {
+        'Accept': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+        ...((options.headers as Record<string, string>) || {})
+    };
+
+    if (xsrfToken) {
+        headers['X-XSRF-TOKEN'] = xsrfToken;
+    }
+
+    const response = await fetch(url, {
+        ...options,
+        headers
+    });
+
+    const isJson = response.headers.get('content-type')?.includes('application/json');
+    const data = isJson ? await response.json() : null;
+
+    if (!response.ok) {
+        const error: any = new Error(response.statusText);
+        error.response = { status: response.status, data };
+        throw error;
+    }
+
+    return { status: response.status, data };
+};
+
 export const joinServer = async (code: string): Promise<[number, string?]> => {
-    return Promise.resolve(await axios.post(addUser.url(), {code: code})
-        .then(() => {
-            router.reload({only: ['servers', 'user']});
-            return [200, 'Successfully joined to server.'] as [number, string];
-        })
-        .catch((err: AxiosError<{ message: string }>) => {
-            return [err.status!, err.response?.data.message];
-        }))
+    try {
+        await fetchJson(addUser.url(), {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ code })
+        });
+        
+        router.reload({only: ['servers', 'user']});
+        return [200, 'Successfully joined to server.'];
+    } catch (err: any) {
+        return [err.response?.status || 500, err.response?.data?.message || err.message];
+    }
 }
 

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -1,11 +1,9 @@
 import {PageProps as InertiaPageProps} from '@inertiajs/core';
-import {AxiosInstance} from 'axios';
 import {PageProps as AppPageProps} from './';
 import Pusher from "pusher-js";
 
 declare global {
     interface Window {
-        axios: AxiosInstance;
         Pusher: typeof Pusher;
     }
 }

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -92,6 +92,7 @@ export interface Channel extends Object {
     name: string;
     type: ChannelType;
     server_id: number;
+    route_key: string;
 }
 
 export interface Server extends Object {
@@ -100,6 +101,7 @@ export interface Server extends Object {
     icon: string | null;
     users: User[] | null;
     roles: Role[] | null;
+    route_key: string;
 }
 
 export interface Perms {

--- a/routes/api.php
+++ b/routes/api.php
@@ -25,21 +25,21 @@ Route::middleware(['web'])->group(function () {
         Route::post('/add-user', 'addUser')->name('.addUser');
         Route::patch('/{server}', 'edit')->name('.edit');
         Route::delete('/{server}/remove-user', 'removeUser')->name('.removeUser');
-        Route::delete('/', 'delete')->name('.delete');
-        Route::delete('/{id}/leave', [ServerController::class, 'leave'])->name('.leave');
+        Route::delete('/{server}', 'delete')->name('.delete');
+        Route::delete('/{server}/leave', [ServerController::class, 'leave'])->name('.leave');
     });
 
     Route::controller(MessageController::class)->prefix('message')->name('message')->group(function () {
-        Route::post('/{channel}', 'create')->name('.create');
+        Route::post('/{server}/{channel}', 'create')->name('.create');
         Route::patch('/{message}', 'edit')->name('.edit');
         Route::delete('/{message}', 'delete')->name('.delete');
     });
 
     Route::controller(ChannelController::class)->prefix('channel')->name('channel')->group(function () {
         Route::post('/{server}', 'create')->name('.create');
-        Route::patch('/{channel}', 'edit')->name('.edit');
-        Route::delete('/{channel}', 'delete')->name('.delete');
-        Route::post('/{channel}/upload', 'upload')->name('.upload');
+        Route::patch('/{server}/{channel}', 'edit')->name('.edit');
+        Route::delete('/{server}/{channel}', 'delete')->name('.delete');
+        Route::post('/{server}/{channel}/upload', 'upload')->name('.upload');
     });
 
     Route::controller(RoleController::class)->prefix('roles')->name('roles')->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,7 +23,7 @@ Route::post('language', function (Request $request) {
 // Server/home routes
 Route::middleware('auth')->group(function () {
     Route::controller(HomeController::class)->prefix('home')->name('home')
-        ->whereNumber(['server', 'channel', 'message', 'whiteboard'])
+        ->whereNumber(['message', 'whiteboard'])
         ->group(function () {
             Route::get('/', 'home')->middleware('verified');
             Route::get('/{server}', 'server')->name('.server');
@@ -40,15 +40,15 @@ Route::middleware('auth')->group(function () {
         );
 
     // Setting routes
-    Route::prefix('settings')->whereNumber('id')->group(function () {
+    Route::prefix('settings')->group(function () {
         Route::controller(ServerController::class)->prefix('server')->group(function () {
-            Route::get('/{id}', 'showSettings')->name('settings.server');
-            Route::post('/{id}', 'update')->name('server.update');
-            Route::delete('/{id}', 'destroy')->name('server.destroy');
+            Route::get('/{server}', 'showSettings')->name('settings.server');
+            Route::post('/{server}', 'update')->name('server.update');
+            Route::delete('/{server}', 'destroy')->name('server.destroy');
         }
         );
-        Route::get('/role/{id}', [RoleController::class, 'showSettings'])->name('settings.role');
-        Route::get('/members/{id}', [RoleController::class, 'showMembers'])->name('settings.members');
+        Route::get('/role/{server}', [RoleController::class, 'showSettings'])->name('settings.role');
+        Route::get('/members/{server}', [RoleController::class, 'showMembers'])->name('settings.members');
     }
     );
 

--- a/tests/Feature/Api/ChannelControllerTest.php
+++ b/tests/Feature/Api/ChannelControllerTest.php
@@ -17,7 +17,7 @@ test('channel upload allows valid audio files', function () {
 
     $file = UploadedFile::fake()->create('audio.mp3', 100, 'audio/mpeg');
 
-    $response = $this->postJson("/api/channel/{$channel->id}/upload", [
+    $response = $this->postJson("/api/channel/{$server->slug}/{$channel->slug}/upload", [
         'audio' => $file,
     ]);
 
@@ -36,7 +36,7 @@ test('channel upload rejects invalid files', function () {
 
     $file = UploadedFile::fake()->create('shell.php', 100, 'application/x-php');
 
-    $response = $this->postJson("/api/channel/{$channel->id}/upload", [
+    $response = $this->postJson("/api/channel/{$server->slug}/{$channel->slug}/upload", [
         'audio' => $file,
     ]);
 

--- a/tests/Feature/Api/MessageControllerTest.php
+++ b/tests/Feature/Api/MessageControllerTest.php
@@ -48,10 +48,10 @@ test('user cannot edit another user\'s message', function () {
 
     // Act as user2 and try to edit user1's message
     $this->actingAs($user2);
-    
+
     // We add this to ensure the exception is converted to a response in the test
     $this->withExceptionHandling();
-    
+
     $response = $this->patch("/api/message/{$message->id}", [
         'mdata' => 'Hacked message',
     ]);

--- a/tests/Feature/Api/MessageControllerTest.php
+++ b/tests/Feature/Api/MessageControllerTest.php
@@ -24,8 +24,7 @@ test('user can edit their own message', function () {
         'mdata' => 'Updated message',
     ]);
 
-    $response->assertStatus(201);
-    $response->assertJson(['message' => 'Message updated']);
+    $response->assertStatus(302);
 
     $this->assertDatabaseHas('messages', [
         'id' => $message->id,
@@ -49,12 +48,15 @@ test('user cannot edit another user\'s message', function () {
 
     // Act as user2 and try to edit user1's message
     $this->actingAs($user2);
+    
+    // We add this to ensure the exception is converted to a response in the test
+    $this->withExceptionHandling();
+    
     $response = $this->patch("/api/message/{$message->id}", [
         'mdata' => 'Hacked message',
     ]);
 
     $response->assertStatus(403);
-    $response->assertJson(['message' => 'Forbidden.']);
 
     $this->assertDatabaseHas('messages', [
         'id' => $message->id,

--- a/tests/Feature/Api/RoleControllerTest.php
+++ b/tests/Feature/Api/RoleControllerTest.php
@@ -29,6 +29,7 @@ test('user without permissions cannot add user to role', function () {
 
     $this->actingAs($user);
 
+    $this->withExceptionHandling();
     $response = $this->post("/api/roles/{$targetRole->id}/add-user/{$targetUser->id}");
 
     $response->assertStatus(403);
@@ -61,7 +62,7 @@ test('user with permissions can add user to role', function () {
 
     $response = $this->post("/api/roles/{$targetRole->id}/add-user/{$targetUser->id}");
 
-    $response->assertStatus(200);
+    $response->assertStatus(302);
 });
 
 test('user without permissions cannot remove user from role', function () {
@@ -91,6 +92,7 @@ test('user without permissions cannot remove user from role', function () {
 
     $this->actingAs($user);
 
+    $this->withExceptionHandling();
     $response = $this->delete("/api/roles/{$targetRole->id}/remove-user/{$targetUser->id}");
 
     $response->assertStatus(403);
@@ -125,5 +127,5 @@ test('user with permissions can remove user from role', function () {
 
     $response = $this->delete("/api/roles/{$targetRole->id}/remove-user/{$targetUser->id}");
 
-    $response->assertStatus(200);
+    $response->assertStatus(302);
 });

--- a/tests/Feature/Api/ServerSettingsSecurityTest.php
+++ b/tests/Feature/Api/ServerSettingsSecurityTest.php
@@ -22,7 +22,7 @@ test('user without permissions cannot view server settings', function () {
 
     $this->actingAs($user);
 
-    $response = $this->get("/settings/server/{$server->id}");
+    $response = $this->get("/settings/server/{$server->slug}");
 
     $response->assertStatus(403);
 });
@@ -45,7 +45,7 @@ test('user with permissions can view server settings', function () {
 
     $this->actingAs($user);
 
-    $response = $this->get("/settings/server/{$server->id}");
+    $response = $this->get("/settings/server/{$server->slug}");
 
     $response->assertStatus(200);
 });

--- a/tests/Feature/HomeTest.php
+++ b/tests/Feature/HomeTest.php
@@ -20,7 +20,7 @@ test('home select server', function () {
     $this->actingAs($user);
 
     $response = $this
-        ->get(route('home.server', ['server' => $user->servers->first()->id]));
+        ->get(route('home.server', ['server' => $user->servers->first()->slug]));
 
     $response->assertOk();
 });
@@ -30,7 +30,7 @@ test('home returns all channels', function () {
     $this->actingAs($user);
 
     $response = $this
-        ->get(route('home.text', ['server' => $user->servers->first()->id]));
+        ->get(route('home.text', ['server' => $user->servers->first()->slug]));
     $response->assertInertia(fn (Assert $page) => $page
         ->has('channels', $user->servers->first()->channels->count())
     );
@@ -43,7 +43,7 @@ test('home select channel', function () {
     $this->actingAs($user);
 
     $response = $this
-        ->get(route('home.text.channel', ['server' => $server->id, 'channel' => $selectedChannel->id]));
+        ->get(route('home.text.channel', ['server' => $server->slug, 'channel' => $selectedChannel->slug]));
     $response->assertInertia(fn (Assert $page) => $page
         ->has('channels', $user->servers->first()->channels->count())
         ->has('selectedChannel')->where('selectedChannel.id', $selectedChannel->id)

--- a/tests/Feature/WhiteboardTest.php
+++ b/tests/Feature/WhiteboardTest.php
@@ -25,7 +25,7 @@ class WhiteboardTest extends TestCase
 
         $response = $this
             ->actingAs($user)
-            ->get("/home/{$server->id}/whiteboard/{$channel->id}");
+            ->get("/home/{$server->slug}/whiteboard/{$channel->slug}");
 
         $response->assertOk();
     }


### PR DESCRIPTION
- Add slug columns to servers and channels with auto-generation
- Switch routes from IDs to slugs, enabling friendly URLs
- Use implicit route model binding, removing manual find/404 checks
- Change API responses to back() redirects; use abort() for errors
- Remove axios dependency